### PR TITLE
Added an option to use a local arduino-cli.yaml to add, for example, custom library paths. Which is a common request.

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,11 @@
           "default": false,
           "markdownDescription": "Use Arduino CLI installed instead of the legacy Arduino IDE. If `#arduino.path#` and `#arduino.commandPath#` are not set, the extension will use a version of Arduino CLI bundled with the extension. (Requires a restart after change)"
         },
+				"arduino.useLocalArduinoCliConfigFile": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Use a local arduino-cli.yaml file instead the default .../Arduino15/arduino-cli.yaml. (Requires a restart after change)"
+				},
         "arduino.path": {
           "type": "string",
           "default": "",

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -668,6 +668,10 @@ export class ArduinoApp {
             }
         }
 
+        if (this.useArduinoCli() && this._settings.useLocalArduinoCliConfigFile) {
+            args.push("--config-file", path.join(ArduinoWorkspace.rootPath, "arduino-cli.yaml"));
+        }
+
         if (dc.buildPreferences) {
             for (const pref of dc.buildPreferences) {
                 // Note: BuildPrefSetting makes sure that each preference

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -25,6 +25,7 @@ export interface IArduinoSettings {
     preferencePath: string;
     preferences: Map<string, string>;
     useArduinoCli: boolean;
+    useLocalArduinoCliConfigFile: boolean;
     usingBundledArduinoCli: boolean;
     analyzeOnSettingChange: boolean;
     reloadPreferences(): void;
@@ -42,6 +43,8 @@ export class ArduinoSettings implements IArduinoSettings {
     private _preferences: Map<string, string>;
 
     private _useArduinoCli: boolean;
+
+    private _useLocalArduinoCliConfigFile: boolean;
 
     private _usingBundledArduinoCli: boolean = false;
 
@@ -62,6 +65,7 @@ export class ArduinoSettings implements IArduinoSettings {
         const platform = os.platform();
         this._commandPath = VscodeSettings.getInstance().commandPath;
         this._useArduinoCli = VscodeSettings.getInstance().useArduinoCli;
+        this._useLocalArduinoCliConfigFile = VscodeSettings.getInstance().useLocalArduinoCliConfigFile;
         await this.tryResolveArduinoPath();
         if (platform === "win32") {
             await this.updateWindowsPath();
@@ -169,6 +173,10 @@ export class ArduinoSettings implements IArduinoSettings {
 
     public get useArduinoCli() {
         return this._useArduinoCli;
+    }
+
+    get useLocalArduinoCliConfigFile() {
+        return this._useLocalArduinoCliConfigFile;
     }
 
     public get usingBundledArduinoCli() {

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -17,6 +17,7 @@ const configKeys = {
     IGNORE_BOARDS: "arduino.ignoreBoards",
     SKIP_HEADER_PROVIDER: "arduino.skipHeaderProvider",
     USE_ARDUINO_CLI: "arduino.useArduinoCli",
+    USE_LOCAL_ARDUINO_CLI_CONFIG_FILE: "arduino.useLocalArduinoCliConfigFile",
     DISABLE_INTELLISENSE_AUTO_GEN: "arduino.disableIntelliSenseAutoGen",
     ANALYZE_ON_OPEN: "arduino.analyzeOnOpen",
     ANALYZE_ON_SETTING_CHANGE: "arduino.analyzeOnSettingChange",
@@ -34,6 +35,7 @@ export interface IVscodeSettings {
     ignoreBoards: string[];
     skipHeaderProvider: boolean;
     useArduinoCli: boolean;
+    useLocalArduinoCliConfigFile: boolean;
     disableIntelliSenseAutoGen: boolean;
     analyzeOnOpen: boolean;
     analyzeOnSettingChange: boolean;
@@ -121,6 +123,14 @@ export class VscodeSettings implements IVscodeSettings {
 
     public setUseArduinoCli(value: boolean): Promise<void> {
         return this.setConfigValue(configKeys.USE_ARDUINO_CLI, value, true);
+    }
+
+    public get useLocalArduinoCliConfigFile(): boolean {
+        return this.getConfigValue(configKeys.USE_LOCAL_ARDUINO_CLI_CONFIG_FILE);
+    }
+
+    public setUseLocalArduinoCliConfigFile(value: boolean): Promise<void> {
+        return this.setConfigValue(configKeys.USE_LOCAL_ARDUINO_CLI_CONFIG_FILE, value, true);
     }
 
     public get skipHeaderProvider(): boolean {


### PR DESCRIPTION
**Many people on the web can't find a solution to make the Arduino-CLI look for their custom libraries in a specific location for each of their projects.**

I propose an option to have the extension look for a local arduino-cli.yaml file at the root of the project in order to be able to define these paths (and also further customize the behavior of the Arduino-CLI according to each project).

<img width="743" alt="Capture d’écran 2025-01-10 à 14 47 54" src="https://github.com/user-attachments/assets/70a0606a-199a-4949-8e24-7efe67becd2d" />
<img width="147" alt="Capture d’écran 2025-01-10 à 14 51 21" src="https://github.com/user-attachments/assets/bb24ac43-c0f5-4a94-be36-5a653b71f2ef" />
<img width="248" alt="Capture d’écran 2025-01-10 à 14 52 42" src="https://github.com/user-attachments/assets/1dfb7770-775e-4472-bc0e-273534cf0826" />

_For reference, here is the list of possibilities offered by this configuration file: https://arduino.github.io/arduino-cli/latest/configuration/_

---------
### Background:

Since the loss of compatibility with the Arduino IDE with version 2 and the mandatory use of the Arduino-CLI, many people have the problem that they do not know how to include their custom libraries anymore:
https://github.com/microsoft/vscode-arduino/issues/1653#issue-1761397421

It used to be possible to place an arduino-cli.yaml file at the root of the project:
https://github.com/microsoft/vscode-arduino/issues/1614#issuecomment-2223040369
https://arduino.github.io/arduino-cli/0.22/configuration/#locations

Unfortunately, for security reasons, the latest versions of the Arduino-CLI no longer support the use of a local file.
https://github.com/arduino/arduino-cli/issues/758
https://arduino.github.io/arduino-cli/1.1/configuration/#locations
Since February 2023, only the use of environment variables and the --config-file option are supported.

The only viable solution is to add an arduino-cli.yaml file in the "Arduino15" directory on your operating system. However, there remains a problem: the paths declared in this way are global, a certain number of users are looking for a way to be able to choose the libraries to use depending on their project.
https://github.com/vscode-arduino/vscode-arduino/issues/50#issuecomment-2518083289

Since VSCode does not support environment variables in this context, the only solution is to modify the Arduino extension for VSCode to use the --config-file parameter of the Arduino-CLI.

So I added an option for the extension to fetch a local arduino-cli.yaml at the root of the project using the config-file parameter, thus solving the problem.